### PR TITLE
[Optional] uploads information about mikey within the team json file

### DIFF
--- a/src/data/team.json
+++ b/src/data/team.json
@@ -1,0 +1,11 @@
+[
+    {
+      "name": "Mikey Nichols",
+      "location": "West Virginia",
+      "email": "mnix@journeytocode.io",
+      "about": "I am an aspiring developer with a strong desire to kick down the door into the tech industry! It has been a great experience thus far working with Team 16 on this project.",
+      "github": "https://github.com/mnichols08",
+      "linkedin": "https://linkedin.com/in/mnix-dev",
+      "twitter": "https://x.com/_m_Nix_"
+    }
+  ]


### PR DESCRIPTION
This is what I was referring to when I mentioned we could collect information about ourself and store it within a JSON file.

Alternatively you can add your information to [this spreadsheet](https://docs.google.com/spreadsheets/d/13PJOXTaiTEJR5EA972PIVOgo-UG6yXRfqwLIJ0ApSQo/edit?usp=sharing) .

This is a completely optional thing to do, but if we participate then when we go to create our footer, we could map over this file and list developers dynamically. The same could happen on a team page as well.