### PR TITLE
Filtering the response from GROQ API to capture the #hex code, name of the color and its description.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,9 +34,9 @@ function App() {
         ],
         model: "llama3-8b-8192",
       });
-      console.log(chatCompletion.choices[0]?.message?.content || "");
+            console.log(chatCompletion.choices[0]?.message?.content || "");
     } catch (error) {
-      console.log(error.message);
+      console.error(error.message);
     }
   };
   const setters = useMemo(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,14 +28,14 @@ function App() {
         messages: [
           {
             role: "user",
-            content: `Given the hex code color ${hexColor}, ${formData.usage} giving me four colors in a ${formData.colorScheme} color scheme.  Your response should be in JSON format.`,
+            content: `Provide a JSON Object that contains a color scheme of four colors generated from the hex code color ${hexColor}. The color scheme should help with ${formData.colorScheme}. Provide details about why each color was picked. Ensure each color has a name and hex code and description with at least 10 characters. The color scheme must be used to ${formData.usage}. The JSON object is an array of objects that contain the following properties: name, hex, description.`,
           },
         ],
         model: "llama3-8b-8192",
       });
       const chatResponse = chatCompletion.choices[0]?.message?.content || ""; // This is the response from the chat model
       const schemeObj = extractJSON(chatResponse); // This extracts the JSON object from the response
-      console.log(schemeObj); 
+      console.log(schemeObj);
       // From here I imagine we can pass the schemeObj to a component that will display the colors
       // This click aslo has access to the formData and hexColor so it doesn't make sense to pass into the extractJSON function
       // Just pass it in here. Remember, we may want to generate an image at this point too. We could write a function for this as well.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
+("use strict");
+import Groq from "groq-sdk";
 import { useState, useMemo, useEffect } from "react";
 import "./App.css";
 import ColorPicker from "./components/ColorPicker";
 import InputForm from "./components/InputForm";
 import Header from "./Header";
 import Footer from "./Footer";
-("use strict");
-import Groq from "groq-sdk";
+
 
 const groq = new Groq({
   apiKey: import.meta.env.VITE_GROQ_API_KEY,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,8 +33,13 @@ function App() {
         ],
         model: "llama3-8b-8192",
       });
-      const chatResponse = chatCompletion.choices[0]?.message?.content || "";
-      console.log(chatResponse);
+      const chatResponse = chatCompletion.choices[0]?.message?.content || ""; // This is the response from the chat model
+      const schemeObj = extractJSON(chatResponse); // This extracts the JSON object from the response
+      console.log(schemeObj); 
+      // From here I imagine we can pass the schemeObj to a component that will display the colors
+      // This click aslo has access to the formData and hexColor so it doesn't make sense to pass into the extractJSON function
+      // Just pass it in here. Remember, we may want to generate an image at this point too. We could write a function for this as well.
+      // That function will need the data that is avaible within this click event.
     } catch (error) {
       console.error(error.message);
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@
 import Groq from "groq-sdk";
 import { useState, useMemo, useEffect } from "react";
 import "./App.css";
+import extractJSON from "./utils/extractJson";
 import ColorPicker from "./components/ColorPicker";
 import InputForm from "./components/InputForm";
 import Header from "./Header";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import InputForm from "./components/InputForm";
 import Header from "./Header";
 import Footer from "./Footer";
 
-
 const groq = new Groq({
   apiKey: import.meta.env.VITE_GROQ_API_KEY,
   dangerouslyAllowBrowser: true, //I'm not sure if this is bad practice
@@ -34,7 +33,8 @@ function App() {
         ],
         model: "llama3-8b-8192",
       });
-            console.log(chatCompletion.choices[0]?.message?.content || "");
+      const chatResponse = chatCompletion.choices[0]?.message?.content || "";
+      console.log(chatResponse);
     } catch (error) {
       console.error(error.message);
     }

--- a/src/utils/extractJson.js
+++ b/src/utils/extractJson.js
@@ -1,0 +1,15 @@
+const extractJSON = (chatResponse) => {
+  const str = chatResponse.replaceAll("json", ""); // This removes the word 'json' from the string if it exists
+  const jsonRegex = /```(.*?)```/s; // regEx for finding a JSON object within a string
+  const jsonMatch = str.match(jsonRegex); // This extracts the JSON object from the string
+
+  if (!jsonMatch) {
+    console.error("No JSON object found.");
+    return;
+  }
+
+  const schemeObj = JSON.parse(jsonMatch[1]); // This parses the JSON object into a JavaScript object
+  return schemeObj;
+};
+
+export default extractJSON;


### PR DESCRIPTION
This PR adds a middleware function that accepts our chat response and outputs an array of colors that should always have 4 colors, each with a title, hex value, and descriptions.

At the moment this is only in the console but piggy backs on the existing function to generate a json object instead of just a string.

I had to modify the prompt in order to maintain consistent results