### PR TITLE
Image middleware and integration with the usage field

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import ColorPicker from "./components/ColorPicker";
 import InputForm from "./components/InputForm";
 import Header from "./Header";
 import Footer from "./Footer";
+import ImageGenerator from "./components/ImageGenerator";
 ("use strict");
 import Groq from "groq-sdk";
 
@@ -67,6 +68,7 @@ function App() {
         <button className="shadow-lg" onClick={handleClick}>
           Get recommendation
         </button>
+        <ImageGenerator />
         <Footer />
       </div>
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,7 @@ function App() {
         <button className="shadow-lg" onClick={handleClick}>
           Get recommendation
         </button>
-        <ImageGenerator />
+        <ImageGenerator prompt={formData.usage}/>
         <Footer />
       </div>
     </>

--- a/src/components/ImageGenerator.jsx
+++ b/src/components/ImageGenerator.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import generateImgURL from "../utils/generateImgURL";
 
-const ImageGenerator = () => {
+const ImageGenerator = ({prompt}) => {
   const [isLoading, setIsLoading] = useState(false);
   const [imgUrl, setImgUrl] = useState("");
   const [error, setError] = useState("");
@@ -18,15 +18,13 @@ const ImageGenerator = () => {
 
   return (
     <form id="image-container">
-      <input required type="text" id="prompt" placeholder="Prompt" />
       <input required type="text" id="colors" placeholder="Colors" />
       <button
         onClick={async () => {
           setIsLoading(true);
-          const prompt = document.getElementById("prompt").value;
           const colors = document.getElementById("colors").value;
           try {
-            const url = generateImgURL(prompt, colors);
+            const url = await generateImgURL(prompt, colors);
             setImgUrl(url);
           } catch (err) {
             setError(err.message);

--- a/src/components/ImageGenerator.jsx
+++ b/src/components/ImageGenerator.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import generateImgURL from "../utils/generateImgURL";
+
+const ImageGenerator = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [imgUrl, setImgUrl] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (imgUrl) {
+      const img = document.createElement("img");
+      img.src = imgUrl;
+      img.id = "generated-image";
+      const container = document.getElementById("image-container");
+      container.appendChild(img);
+    }
+  }, [imgUrl]);
+
+  return (
+    <form id="image-container">
+      <input required type="text" id="prompt" placeholder="Prompt" />
+      <input required type="text" id="colors" placeholder="Colors" />
+      <button
+        onClick={async () => {
+          setIsLoading(true);
+          const prompt = document.getElementById("prompt").value;
+          const colors = document.getElementById("colors").value;
+          try {
+            const url = generateImgURL(prompt, colors);
+            setImgUrl(url);
+          } catch (err) {
+            setError(err.message);
+          } finally {
+            setIsLoading(false);
+          }
+        }}
+        disabled={isLoading}
+      >
+        Generate Image
+      </button>
+      {isLoading && <p>Loading...</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+    </form>
+  );
+};
+
+export default ImageGenerator;

--- a/src/utils/generateImg.js
+++ b/src/utils/generateImg.js
@@ -1,0 +1,6 @@
+const generateImgURL = (prompt, colors) => {
+    const url = `https://openai-api-u24k.onrender.com/v49/img/${prompt}/${colors}`;
+    return url;
+}
+
+export default generateImgURL;

--- a/src/utils/generateImg.js
+++ b/src/utils/generateImg.js
@@ -1,6 +1,0 @@
-const generateImgURL = (prompt, colors) => {
-    const url = `https://openai-api-u24k.onrender.com/v49/img/${prompt}/${colors}`;
-    return url;
-}
-
-export default generateImgURL;

--- a/src/utils/generateImgURL.js
+++ b/src/utils/generateImgURL.js
@@ -1,0 +1,8 @@
+const generateImgURL = async (prompt, colors) => {
+    const url = await fetch(
+        `https://openai-api-u24k.onrender.com/v49/img/${prompt}/${colors}`
+      ).then((res) => res.json());
+    return url;
+}
+
+export default generateImgURL;


### PR DESCRIPTION
This adds the prompt back to the main screen temporarily for testing. The design file has this screen at the very end so we just need to hold onto the url in the end which is what the middleware function does. 

The front-end portion of this can be removed at any point, or i can remove it before merge if requested as well.